### PR TITLE
Getting seconds from milliseconds

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -46,8 +46,10 @@ class App extends Component {
   signData = async () => {
     const { web3, accounts, contract } = this.state;
     var signer = accounts[0];
-    var deadline = Date.now() + 100000;
-    console.log(deadline);
+    var milsec_deadline = Date.now() / 1000 + 100;
+    console.log(milsec_deadline, "milisec");
+    var deadline = parseInt(String(milsec_deadline).slice(0, 10));
+    console.log(deadline, "sec");
     var x = 157;
 
     web3.currentProvider.sendAsync({


### PR DESCRIPTION
As described in Solidity documentation block.timestamp global variable give us in return seconds (https://docs.soliditylang.org/en/v0.8.15/cheatsheet.html?highlight=global%20variables#global-variables) and JavaScript Data.now() return to us miliseconds. 

In attempt to use comparison operator inside require statement in SimpleStorage.sol  require(block.timestamp < deadline, "Signed transaction expired"); we will need to transform milisecond into seconds and to add arbitrary number of seconds as time limit we want to impose to be respected before our data payload will be seen as invalid. 
